### PR TITLE
Add missing 'main' attribute to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -10,6 +10,7 @@
     "angular",
     "parallax"
   ],
+  "main": "./scripts/angular-parallax.js",
   "license": "MIT",
   "private": true,
   "ignore": [


### PR DESCRIPTION
`bower.json` should include a `main` attribute so that tools like for example [grunt-bower-install](https://github.com/stephenplusplus/grunt-bower-install) can automatically include the required library files (JS, CSS) in the HTML file or use them during the build process.
