### PR TITLE
Make source code uglify-safe.

### DIFF
--- a/scripts/angular-parallax.js
+++ b/scripts/angular-parallax.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('angular-parallax', [
-]).directive('parallax', function($window) {
+]).directive('parallax', ['$window', function($window) {
   return {
     restrict: 'A',
     scope: {
@@ -14,8 +14,10 @@ angular.module('angular-parallax', [
         elem.css('left', $scope.parallaxHorizontalOffset + "px");
 
         var calcValY = $window.pageYOffset * $scope.parallaxRatio;
-        if (calcValY <= $window.innerHeight)
-          elem.css('top', (calcValY < $scope.parallaxVerticalOffset ? $scope.parallaxVerticalOffset : calcValY) + "px");
+        if (calcValY <= $window.innerHeight) {
+          var top = (calcValY < $scope.parallaxVerticalOffset ? $scope.parallaxVerticalOffset : calcValY);
+          elem.css('top', top + "px");
+        }
       }
 
       setPosition();
@@ -26,7 +28,7 @@ angular.module('angular-parallax', [
       }
     }  // link function
   };
-}).directive('parallaxBackground', function($window) {
+}]).directive('parallaxBackground', ['$window', function($window) {
   return {
     restrict: 'A',
     transclude: true,
@@ -47,4 +49,4 @@ angular.module('angular-parallax', [
       }
     }  // link function
   };
-});
+}]);


### PR DESCRIPTION
Prevent tools like [UglifyJS](https://github.com/mishoo/UglifyJS) from messing with dependency variable names. Before that fix I would get errors like `Error: [$injector:unpr] Unknown provider: aProvider <- a <- parallaxDirective`
