### PR TITLE
Using transforms for a better perf

### DIFF
--- a/scripts/angular-parallax.js
+++ b/scripts/angular-parallax.js
@@ -17,7 +17,7 @@ angular.module('angular-parallax', [
         var calcValY = $window.pageYOffset * ($scope.parallaxRatio ? $scope.parallaxRatio : 1.1 );
         if (calcValY <= $window.innerHeight) {
           var topVal = (calcValY < $scope.parallaxVerticalOffset ? $scope.parallaxVerticalOffset : calcValY);
-          elem.css('top', topVal + "px");
+          elem.css('transform','translateY(' +topVal+ 'px)');
         }
       };
 


### PR DESCRIPTION
I prevented your plugin for provoking jank on webpages by using hardware-accelerated css transforms. 
See this [article](http://www.html5rocks.com/en/tutorials/speed/parallax/) of Paul Lewis.