### PR TITLE
Allow percentages in the horizontal offset

### DIFF
--- a/scripts/angular-parallax.js
+++ b/scripts/angular-parallax.js
@@ -11,10 +11,12 @@ angular.module('angular-parallax', [
     },
     link: function($scope, elem, attrs) {
       var setPosition = function () {
+        if(!$scope.parallaxHorizontalOffset) $scope.parallaxHorizontalOffset = '0';
         var calcValY = $window.pageYOffset * ($scope.parallaxRatio ? $scope.parallaxRatio : 1.1 );
         if (calcValY <= $window.innerHeight) {
           var topVal = (calcValY < $scope.parallaxVerticalOffset ? $scope.parallaxVerticalOffset : calcValY);
-          elem.css('transform','translate(' + $scope.parallaxHorizontalOffset + 'px, ' +topVal+ 'px)');
+          var hozVal = ($scope.parallaxHorizontalOffset.indexOf("%") === -1 ? $scope.parallaxHorizontalOffset + 'px' : $scope.parallaxHorizontalOffset);
+          elem.css('transform', 'translate(' + hozVal + ', ' + topVal + 'px)');
         }
       };
 


### PR DESCRIPTION
This will allow people to use percentages like `50%` in the horizontal offset. Combine this with some other css and you can center elements horizontally (which is what I was looking for in #19).