### PR TITLE
Allow vertical offset for backgrounds

### DIFF
--- a/scripts/angular-parallax.js
+++ b/scripts/angular-parallax.js
@@ -36,7 +36,7 @@ angular.module('angular-parallax', [
     },
     link: function($scope, elem, attrs) {
       var setPosition = function () {
-        var calcValY = (elem.prop('offsetTop') - $window.pageYOffset) * ($scope.parallaxRatio ? $scope.parallaxRatio : 1.1 );
+        var calcValY = (elem.prop('offsetTop') - $window.pageYOffset) * ($scope.parallaxRatio ? $scope.parallaxRatio : 1.1 )  - ( attrs.parallaxVerticalOffset || 0);
         // horizontal positioning
         elem.css('background-position', "50% " + calcValY + "px");
       };


### PR DESCRIPTION
Allows for an attribute to be set, which will be subtracted from the calculated y position. Defaults to 0.